### PR TITLE
Fix shop visuals and add NPC chat following

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,16 @@ project(GameProject)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(RAYLIB_DIR "${CMAKE_SOURCE_DIR}/external/raylib")
+set(BULLET_DIR "${CMAKE_SOURCE_DIR}/external/bullet")
+
+if(EXISTS "${RAYLIB_DIR}")
+    set(raylib_DIR "${RAYLIB_DIR}")
+endif()
+if(EXISTS "${BULLET_DIR}")
+    set(BULLET_ROOT_DIR "${BULLET_DIR}")
+endif()
+
 find_package(raylib REQUIRED)
 find_package(Bullet REQUIRED)
 

--- a/external/README.md
+++ b/external/README.md
@@ -1,0 +1,3 @@
+This folder is reserved for local copies of third-party libraries.
+Place the precompiled raylib and Bullet libraries in the respective
+subdirectories so the project can be built without external downloads.

--- a/external/bullet/README.md
+++ b/external/bullet/README.md
@@ -1,0 +1,1 @@
+Place Bullet source or compiled library here.

--- a/external/raylib/README.md
+++ b/external/raylib/README.md
@@ -1,0 +1,1 @@
+Place raylib source or compiled library here.

--- a/include/ai/NPCChatSystem.h
+++ b/include/ai/NPCChatSystem.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "raylib.h"
+#include "objects/GameObject.h"
 
 // NPC Chat System for Romanian comments without diacritics
 class NPCChatSystem {
@@ -14,6 +15,7 @@ class NPCChatSystem {
     float displayTime;
     float maxDisplayTime;
     Vector3 worldPosition;
+    const GameObject* follow;
     bool isActive;
 
     ChatMessage()
@@ -21,6 +23,7 @@ class NPCChatSystem {
           displayTime(0.0f),
           maxDisplayTime(3.0f),
           worldPosition({0, 0, 0}),
+          follow(nullptr),
           isActive(false) {}
   };
 
@@ -41,7 +44,8 @@ class NPCChatSystem {
   ~NPCChatSystem() = default;
 
   void addMessage(const std::string& message, Vector3 position,
-                  float duration = 3.0f);
+                  float duration = 3.0f,
+                  const GameObject* follow = nullptr);
   void update(float deltaTime);
   void drawAllMessages(Camera3D camera) const;
 

--- a/include/ai/NavMesh.h
+++ b/include/ai/NavMesh.h
@@ -40,7 +40,8 @@ class NavMesh {
   void addWallObstacle(Vector3 wallPos, Vector3 wallSize);
   void removeObstacle(Vector3 position, Vector3 size);
   void markNodesInArea(Vector3 center, Vector3 size, bool walkable,
-                       float expansionFactor = 0.5f);
+                       float expansionFactor = 0.5f,
+                       bool projectToGround = false);
   bool isPositionBlocked(Vector3 position) const;
 
   void defineShopEntrance(Vector3 entrancePos, Vector3 entranceSize);

--- a/include/shop/Fruit.h
+++ b/include/shop/Fruit.h
@@ -35,6 +35,7 @@ class Fruit : public Sphere {
   void resetFruit();
 
   void interact() override;
+  void draw() const override;
 
   static Color getFruitColor(FruitType type);
   static float getFruitRadius(FruitType type);

--- a/include/shop/Shop.h
+++ b/include/shop/Shop.h
@@ -48,10 +48,12 @@ class Shop : public CubeObject {
 
   void interact() override;
   void update(float deltaTime) override;
+  void draw() const override;
   std::unique_ptr<GameObject> clone() const override;
 
  private:
-  void addWall(Vector3 position, Vector3 size, Color color = DARKBROWN);
+  void addWall(Vector3 position, Vector3 size, Color color = DARKBROWN,
+               bool blockNavMesh = true);
   Vector3 calculateInteriorBounds() const;
   void finalizeNavMesh();
 };

--- a/src/GameWorld.cpp
+++ b/src/GameWorld.cpp
@@ -166,10 +166,12 @@ void GameWorld::addObjectAsObstacleDeferred(std::shared_ptr<GameObject> object,
     std::string obstacleType = type.empty() ? object->getObstacleType() : type;
 
     // Add obstacle but don't rebuild connections yet
-    navigationMesh->markNodesInArea(pos, size, false,
-                                    obstacleType == "shelf"  ? 0.7f
-                                    : obstacleType == "wall" ? 0.3f
-                                                             : 0.5f);
+    navigationMesh->markNodesInArea(
+        pos, size, false,
+        obstacleType == "shelf"  ? 0.7f
+        : obstacleType == "wall" ? 0.3f
+                                  : 0.5f,
+        obstacleType == "shelf");
 
   } else {
   }

--- a/src/ai/NPC.cpp
+++ b/src/ai/NPC.cpp
@@ -326,7 +326,7 @@ void NPC::sayMessage(const std::string& context) const {
     }
 
     if (!message.empty()) {
-      chatSystem->addMessage(message, getPosition());
+      chatSystem->addMessage(message, getPosition(), 3.0f, this);
     }
   } else {
     if (!chatSystem) {

--- a/src/ai/NPCChatSystem.cpp
+++ b/src/ai/NPCChatSystem.cpp
@@ -69,10 +69,11 @@ void NPCChatSystem::initializeMessages() {
 }
 
 void NPCChatSystem::addMessage(const std::string& message, Vector3 position,
-                               float duration) {
+                               float duration, const GameObject* follow) {
   ChatMessage newMessage;
   newMessage.text = message;
   newMessage.worldPosition = position;
+  newMessage.follow = follow;
   newMessage.maxDisplayTime = duration;
   newMessage.displayTime = 0.0f;
   newMessage.isActive = true;
@@ -88,6 +89,9 @@ void NPCChatSystem::update(float deltaTime) {
 
   for (auto& message : activeMessages) {
     if (message.isActive) {
+      if (message.follow) {
+        message.worldPosition = message.follow->getPosition();
+      }
       message.displayTime += deltaTime;
       if (message.displayTime >= message.maxDisplayTime) {
         message.isActive = false;

--- a/src/shop/Fruit.cpp
+++ b/src/shop/Fruit.cpp
@@ -87,6 +87,12 @@ void Fruit::interact() {
   }
 }
 
+void Fruit::draw() const {
+  if (!isPicked) {
+    Sphere::draw();
+  }
+}
+
 // Clone method for polymorphism
 std::unique_ptr<GameObject> Fruit::clone() const {
   return std::make_unique<Fruit>(position, type);

--- a/src/shop/Shop.cpp
+++ b/src/shop/Shop.cpp
@@ -53,7 +53,7 @@ void Shop::buildWalls() {
           {wallThickness, wallHeight, shopSize.z});
 
   addWall({shopPos.x, shopPos.y + shopSize.y / 2.0f, shopPos.z},
-          {shopSize.x, wallThickness, shopSize.z});
+          {shopSize.x, wallThickness, shopSize.z}, DARKBROWN, false);
 }
 
 void Shop::createShelves() {
@@ -196,13 +196,22 @@ std::unique_ptr<GameObject> Shop::clone() const {
   return std::make_unique<Shop>(*this);
 }
 
-void Shop::addWall(Vector3 position, Vector3 size, Color color) {
+void Shop::draw() const {
+  // Do not draw the base cube to avoid the falling beige body
+}
+
+void Shop::addWall(Vector3 position, Vector3 size, Color color,
+                   bool blockNavMesh) {
   auto wall = std::make_shared<CubeObject>(position, size, color, true, "",
                                            false, true, true);
   walls.push_back(wall);
 
   if (GameWorld* world = GameWorld::getInstance(nullptr)) {
-    world->addObjectAsObstacleDeferred(wall);
+    if (blockNavMesh) {
+      world->addObjectAsObstacleDeferred(wall);
+    } else {
+      world->addObject(wall);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- stop drawing shop cube and prevent navmesh blocking for ceiling
- support NPC chat bubbles that follow NPCs
- mark shelf nodes using new projectToGround flag
- hide picked fruit and update navmesh call
- allow local dependencies via `external` folder

## Testing
- `cmake ..` *(fails: missing raylib)*
- `make` *(fails: no makefile due to previous error)*

------
https://chatgpt.com/codex/tasks/task_e_684ae29a33e8832ca093e07c7f2615b3